### PR TITLE
Add print-session-id extension

### DIFF
--- a/extensions/print-session-id.ts
+++ b/extensions/print-session-id.ts
@@ -1,0 +1,14 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+export default function (pi: ExtensionAPI) {
+  pi.on("session_shutdown", async (_event, ctx) => {
+    const sessionFile = ctx.sessionManager.getSessionFile();
+    if (sessionFile && ctx.hasUI) {
+      pi.sendMessage({
+        customType: "session-info",
+        content: `\n🔖 Session: ${sessionFile}\n   Resume with: pi --session ${sessionFile}\n`,
+        display: true,
+      });
+    }
+  });
+}


### PR DESCRIPTION
Ports the `print-session-id` extension from the user-level agent config (`~/.pi/agent/extensions/`) into this project package.

On session shutdown, it prints the session file path and a resume command so you can easily pick up where you left off.