### PR TITLE
Add post-merge cleanup steps to workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,10 @@
 - Never commit directly to main
 - Always create a feature branch for changes
 - Push the branch and open a PR
+- After a PR is merged, clean up locally:
+  - Switch to main and pull
+  - Delete the local feature branch
+  - Prune stale remote tracking refs
 
 # Commit Messages
 


### PR DESCRIPTION
Documents the local cleanup steps to run after merging a PR: switch to main, pull, delete the local branch, and prune stale remote refs.