### PR TITLE
Friendlier session info on shutdown

### DIFF
--- a/extensions/print-session-id.ts
+++ b/extensions/print-session-id.ts
@@ -1,12 +1,44 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import * as path from "path";
+
+function formatSessionInfo(sessionFile: string, sessionName?: string): string {
+  const filename = path.basename(sessionFile);
+
+  // Extract timestamp and short ID from filename
+  // Format: 2026-03-24T21-35-01-260Z_cba0e307-253b-4b3b-b8be-0cba249dc065.jsonl
+  const parts = filename.replace(/\.jsonl$/, "").split("_");
+  const timestamp = parts[0] || "";
+  const uuid = parts.slice(1).join("_");
+  const shortId = uuid.slice(0, 8);
+
+  // Parse timestamp into a readable format
+  let timeStr = timestamp;
+  const timeMatch = timestamp.match(
+    /^(\d{4})-(\d{2})-(\d{2})T(\d{2})-(\d{2})-(\d{2})/,
+  );
+  if (timeMatch) {
+    const [, year, month, day, hour, min] = timeMatch;
+    const date = new Date(
+      `${year}-${month}-${day}T${hour}:${min}:00Z`,
+    );
+    timeStr = "started " + date.toLocaleString(undefined, {
+      hour: "numeric",
+      minute: "2-digit",
+    });
+  }
+
+  const label = sessionName ? `"${sessionName}"` : `anon (${shortId})`;
+  return `\n📌 ${label} • ${timeStr} • resume: pi --session ${shortId}\n`;
+}
 
 export default function (pi: ExtensionAPI) {
   pi.on("session_shutdown", async (_event, ctx) => {
     const sessionFile = ctx.sessionManager.getSessionFile();
     if (sessionFile && ctx.hasUI) {
+      const sessionName = pi.getSessionName();
       pi.sendMessage({
         customType: "session-info",
-        content: `\n🔖 Session: ${sessionFile}\n   Resume with: pi --session ${sessionFile}\n`,
+        content: formatSessionInfo(sessionFile, sessionName),
         display: true,
       });
     }


### PR DESCRIPTION
Makes the session info message on shutdown much more readable:

- **Named session:** `📌 "refactor-auth" • started 4:35 PM • resume: pi --session cba0e307`
- **Unnamed session:** `📌 anon (cba0e307) • started 4:35 PM • resume: pi --session cba0e307`

Before it showed the full raw path twice, which was pretty gnarly:
```
🔖 Session: /Users/jon/.pi/agent/sessions/--Users-jon-code-pizza--/2026-03-24T21-35-01-260Z_cba0e307-253b-4b3b-b8be-0cba249dc065.jsonl
   Resume with: pi --session /Users/jon/.pi/agent/sessions/--Users-jon-code-pizza--/2026-03-24T21-35-01-260Z_cba0e307-253b-4b3b-b8be-0cba249dc065.jsonl
```