### PR TITLE
Update binks-worktree skill to use dev tree

### DIFF
--- a/skills/binks-worktree/SKILL.md
+++ b/skills/binks-worktree/SKILL.md
@@ -1,127 +1,101 @@
 ---
 name: binks-worktree
-description: Create and manage git worktrees for the Binks monorepo. Use when the user wants to work on a separate branch in parallel, create a worktree, list worktrees, switch to a worktree, or clean up old worktrees.
+description: Create and manage git worktrees for Binks in World. Use when the user wants to work on a separate branch in parallel, create a worktree, list worktrees, switch to a worktree, or clean up old worktrees.
 ---
 
 # Binks Worktree Management
 
-## Key Concept
+Binks lives in World at `//areas/internal-services/binks/web`. World has its own worktree tooling (`dev tree`) that handles sparse checkout, the expected directory layout, and integration with other World tooling.
 
-The Binks repo has a **split between git root and working directory**:
-
-- **Git root**: `/Users/jon/src/github.com/Shopify/binks`
-- **Working directory**: `<git-root>/areas/internal-services/binks/web`
-
-When creating worktrees, they must be created relative to the **git root**, but after creation you typically want to work from the `areas/internal-services/binks/web` subdirectory inside the new worktree.
-
-Worktrees are created as **siblings** of the main repo, named `binks-<name>`:
-
-```
-/Users/jon/src/github.com/Shopify/
-├── binks/                          ← main worktree (git root)
-├── binks-my-feature/               ← additional worktree
-└── binks-enrollment-due-diligence/ ← additional worktree
-```
-
-## Resolving Paths
-
-Always derive paths dynamically from the current working directory. Don't hardcode paths.
-
-```bash
-# Get the git root from wherever we are
-GIT_ROOT=$(git rev-parse --show-toplevel)
-
-# Worktrees live as siblings of the git root
-WORKTREE_PARENT=$(dirname "$GIT_ROOT")
-
-# The repo basename (should be "binks")
-REPO_NAME=$(basename "$GIT_ROOT")
-
-# The working subdirectory relative to git root
-WORK_SUBDIR="areas/internal-services/binks/web"
-```
+**Always use `dev tree` — never raw `git worktree` commands.** World worktrees live at `~/world/trees/<name>/src`, not as siblings of the git root.
 
 ## Operations
 
 ### List Worktrees
 
 ```bash
-git worktree list
+dev tree list
 ```
+
+The current worktree is marked with `*`.
 
 ### Create a Worktree
 
-When the user asks to create a worktree for a branch or feature:
+```bash
+# Create a worktree with a new branch
+dev tree add <worktree-name> -b <branch-name>
 
-1. Derive a short name from the branch (e.g., `my-feature` from `my-feature-branch`)
-2. Create the worktree as a sibling directory
+# Create and immediately switch into it
+dev tree add <worktree-name> -b <branch-name> --switch
+```
+
+The worktree will be at `~/world/trees/<worktree-name>/src`.
+
+After creation, create a tmux session pointed at the Binks web directory:
 
 ```bash
-GIT_ROOT=$(git rev-parse --show-toplevel)
-WORKTREE_PARENT=$(dirname "$GIT_ROOT")
-REPO_NAME=$(basename "$GIT_ROOT")
-NAME="<short-name>"
-
-# For a new branch:
-git worktree add "${WORKTREE_PARENT}/${REPO_NAME}-${NAME}" -b "<branch-name>"
-
-# For an existing branch:
-git worktree add "${WORKTREE_PARENT}/${REPO_NAME}-${NAME}" "<branch-name>"
+tmux new-session -d -s "binks-<worktree-name>" -c "$HOME/world/trees/<worktree-name>/src/areas/internal-services/binks/web"
 ```
 
-3. Create a tmux session for the new worktree, starting in the web working directory:
+Tell the user:
+- Switch with: `tmux switch-client -t binks-<worktree-name>` (or `Ctrl-b s` to pick)
+- They'll likely need to run `dev up` in the new worktree before working
+
+### Switch to a Worktree
 
 ```bash
-WORKTREE_WEB="${WORKTREE_PARENT}/${REPO_NAME}-${NAME}/${WORK_SUBDIR}"
-SESSION_NAME="${REPO_NAME}-${NAME}"
-
-tmux new-session -d -s "${SESSION_NAME}" -c "${WORKTREE_WEB}"
+dev tree switch <worktree-name>
 ```
 
-4. Tell the user the worktree and tmux session are ready, and how to switch:
+Pass `-` to jump back to the previous worktree (like `cd -`).
 
+### Show Worktree Info
+
+```bash
+dev tree show <worktree-name>
+# or for current worktree:
+dev tree show .
 ```
-tmux switch-client -t <session-name>
-```
-
-Or they can use `Ctrl-b s` to pick from the session list.
-
-5. If `dev` setup is needed, mention they may want to run `dev up` once they switch to the session.
 
 ### Remove a Worktree
 
 ```bash
-GIT_ROOT=$(git rev-parse --show-toplevel)
-WORKTREE_PARENT=$(dirname "$GIT_ROOT")
-REPO_NAME=$(basename "$GIT_ROOT")
-NAME="<short-name>"
-SESSION_NAME="${REPO_NAME}-${NAME}"
-
-# Kill the tmux session if it exists
-tmux kill-session -t "${SESSION_NAME}" 2>/dev/null
+# Kill the tmux session if one exists
+tmux kill-session -t "binks-<worktree-name>" 2>/dev/null
 
 # Remove the worktree
-git worktree remove "${WORKTREE_PARENT}/${REPO_NAME}-${NAME}"
+dev tree remove <worktree-name>
+
+# Force remove if dirty
+dev tree remove <worktree-name> --force
 ```
 
 If the worktree has uncommitted changes, warn the user and ask before using `--force`.
 
-### Prune Stale Worktrees
+Bulk cleanup options:
+```bash
+# Remove worktrees whose PRs have been merged
+dev tree remove --merged
+
+# Remove worktrees whose PRs have been closed (unmerged)
+dev tree remove --closed
+```
+
+## Naming
+
+Use short, descriptive worktree names. The branch can differ from the worktree name via `-b`:
 
 ```bash
-git worktree prune
+dev tree add ruby4 -b ruby4-upgrade
 ```
 
 ## Error Handling
 
-If any command fails (e.g., branch already exists, worktree directory already exists, tmux server not running), **stop immediately** and show the user the error. Do not attempt to recover or retry.
+If any command fails, **stop immediately** and show the user the error. Do not attempt to recover or retry.
 
 ## Tips
 
 - Always confirm the worktree name with the user before creating
-- When listing, highlight which worktree the user is currently in
-- After creating a worktree, remind the user that their `cd` target is the **web subdirectory**, not the worktree root
-- If the user just says "make a worktree" without a branch name, ask what branch/feature name they want
-- Always create a tmux session alongside the worktree so the user can jump straight in
-- When removing a worktree, clean up its tmux session too
-- The tmux session name matches the worktree directory name (e.g., `binks-my-feature`)
+- After creating, remind the user to run `dev up` in the new worktree
+- When removing, clean up the tmux session too
+- `dev tree remove --merged` is handy for periodic cleanup

--- a/skills/binks-worktree/SKILL.md
+++ b/skills/binks-worktree/SKILL.md
@@ -38,6 +38,7 @@ tmux new-session -d -s "binks-<worktree-name>" -c "$HOME/world/trees/<worktree-n
 ```
 
 Tell the user:
+
 - Switch with: `tmux switch-client -t binks-<worktree-name>` (or `Ctrl-b s` to pick)
 - They'll likely need to run `dev up` in the new worktree before working
 
@@ -73,6 +74,7 @@ dev tree remove <worktree-name> --force
 If the worktree has uncommitted changes, warn the user and ask before using `--force`.
 
 Bulk cleanup options:
+
 ```bash
 # Remove worktrees whose PRs have been merged
 dev tree remove --merged


### PR DESCRIPTION
Replace raw `git worktree` commands with World's `dev tree` tooling, which handles sparse checkout, directory layout, and integration with other World tooling.

### Changes

- **Migrate all operations** from `git worktree` to `dev tree` (`list`, `add`, `remove`)
- **Remove manual path resolution** — no more `GIT_ROOT`, `WORKTREE_PARENT`, `REPO_NAME` bash scripting or hardcoded paths
- **Add new operations** — `switch` and `show` commands that weren't previously covered
- **Add bulk cleanup** — `dev tree remove --merged` and `--closed` for housekeeping
- **Simplify create/remove workflows** — cleaner tmux integration, less boilerplate
- **Update worktree paths** — from sibling directories to `~/world/trees/<name>/src`
- **Add naming section** — documents the `-b` flag for diverging worktree/branch names

Net reduction of 26 lines while covering more functionality.